### PR TITLE
apply default config data from 'config.json' when start ioter. save config data to 'config.json' when exit program

### DIFF
--- a/src/auto_onboarding/auto_onboardingmain.py
+++ b/src/auto_onboarding/auto_onboardingmain.py
@@ -79,7 +79,6 @@ class auto_onboardingWindow(QMainWindow):
         self.report = report()
         self.test_category = MULTI_DEVICE
         self.force_quit = False
-        self.device_name = []
         uic.loadUi(Utils.get_view_path("auto_onboardingWindow.ui"), self)
         self.setWindowTitle("Auto onboarding")
         self.chkbox_all.stateChanged.connect(self.toggle_chkbox_all)
@@ -218,6 +217,8 @@ class auto_onboardingWindow(QMainWindow):
         self.objs[index].setupUi(self, comport, vendor)
         self.objs[index].index = index
         self.objs[index].discriminator.setValue(3840+index)
+        self.parent.default_set_thread_type(self.objs[index].combo_thread_type)
+        self.parent.default_set_thread_debug_level(self.objs[index].combo_debug_level)
         self.update()
         self.objs[index].layoutWidget.show()
         self.adjust_geometry()

--- a/src/auto_onboarding/autod.py
+++ b/src/auto_onboarding/autod.py
@@ -53,9 +53,6 @@ class AutoDeviceState():
     REMOVING = 3
 
 
-debug = 0
-
-
 class simpleDlg(QDialog):
     def __init__(self, title, content):
         super(simpleDlg, self).__init__()
@@ -80,6 +77,7 @@ class autoDevice(QThread):
         self.comport = None
         self.device_num = None
         self.is_request = dict()
+        self.debug = False
         # print("autoDevice")
 
     def run(self):
@@ -196,7 +194,7 @@ class autoDevice(QThread):
             if obj and stair == ONBOARDING_ADDITIONAL_ADD_BUTTON:
                 if obj.getText() in [self.get_smartthings_view_id(ADD_DEVICE_KOR),
                                      self.get_smartthings_view_id(ADD_DEVICE_ENG)]:
-                    if debug == 1:
+                    if self.debug == True:
                         print(
                             f"stair::ONBOARDING_ADDITIONAL_ADD_BUTTON, obj={obj}")
                     obj.touch()
@@ -204,7 +202,7 @@ class autoDevice(QThread):
             elif not obj and stair == ONBOARDING_ADDITIONAL_ADD_BUTTON:
                 obj = self.get_obj(str(stair), True)
                 if obj:
-                    if debug == 1:
+                    if self.debug == True:
                         print(
                             f"stair::ONBOARDING_ADDITIONAL_ADD_BUTTON, obj={obj}")
                     obj.touch()
@@ -213,30 +211,30 @@ class autoDevice(QThread):
                     obj = self.get_obj(
                         str(ONBOARDING_MANUAL_PAIRING_CODE_BOTTON))
                     if obj:
-                        if debug == 1:
+                        if self.debug == True:
                             print(
                                 f"stair::ONBOARDING_MANUAL_PAIRING_CODE_BOTTON, obj={obj}")
                         obj.touch()
                         stair += 2
             elif obj and stair == ONBOARDING_MANUAL_PAIRING_CODE_TEXTBOX:
-                if debug == 1:
+                if self.debug == True:
                     print(
                         f"stair::ONBOARDING_MANUAL_PAIRING_CODE_TEXTBOX, obj={obj}")
                 obj.type(self.pairing_code)
                 stair += 1
             elif obj and stair == ONBOARDING_MATTER_DEVICE_NAME_CHANGE:
-                if debug == 1:
+                if self.debug == True:
                     print(
                         f"stair::ONBOARDING_MATTER_DEVICE_NAME_CHANGE, obj={obj}")
                 obj.setText(self.device_name)
                 stair += 1
             elif obj and stair == ONBOARDING_MATTER_DEVICE_NAME_CHANGE_DONE:
-                if debug == 1:
+                if self.debug == True:
                     print(
                         f"stair::ONBOARDING_MATTER_DEVICE_NAME_CHANGE_DONE, obj={obj}")
                 if self.device.isKeyboardShown():
                     self.device.press("BACK")
-                    if debug == 1:
+                    if self.debug == True:
                         print(
                             f"stair::ONBOARDING_MATTER_DEVICE_NAME_CHANGE_DONE, keyboard down")
                     QTest.qWait(2000)
@@ -244,35 +242,35 @@ class autoDevice(QThread):
                 QTest.qWait(12000)
                 stair += 1
             elif stair == ONBOARDING_DONE_BACK_TO_FIRST_SCREEN:
-                if debug == 1:
+                if self.debug == True:
                     print("stair::ONBOARDING_DONE_BACK_TO_FIRST_SCREEN")
                 obj = self.get_obj("text:" + self.device_name, True)
                 if obj or self.count >= 3:
-                    if debug == 1:
+                    if self.debug == True:
                         print(f"obj={obj}")
                     self.vc.device.press("BACK")
                     QTest.qWait(3000)
-                    if debug == 1:
+                    if self.debug == True:
                         print("press BACK")
                     return True
                 else:
-                    if debug == 1:
+                    if self.debug == True:
                         print(
                             f"stair::ONBOARDING_DONE_BACK_TO_FIRST_SCREEN {self.device_name} not found")
                     self.count += 1
             elif obj:
-                if debug == 1:
+                if self.debug == True:
                     print(f"stair::{stair}, obj={obj}")
                 obj.touch()
                 QTest.qWait(1000)
                 stair += 1
             elif not obj:
                 if stair == ONBOARDING_MATTER_DEVICE_NAME_CHANGE:
-                    if debug == 1:
+                    if self.debug == True:
                         print("waiting download plugin in SmartThings...")
                     self.view_dump(5)
                 else:
-                    if debug == 1:
+                    if self.debug == True:
                         print(f"not found stair::{stair}'s obj")
                     self.view_dump()
 
@@ -283,7 +281,7 @@ class autoDevice(QThread):
             if err:
                 if err.getText() in [self.get_smartthings_view_id(ERROR_OCCUR_KOR),
                                      self.get_smartthings_view_id(ERROR_OCCUR_ENG)]:
-                    if debug == 1:
+                    if self.debug == True:
                         print(err)
                     self.screenshot()
                     err2 = self.get_obj(
@@ -291,7 +289,7 @@ class autoDevice(QThread):
                     err2.touch()
                     QTest.qWait(1000)
                     self.vc.device.press("BACK")
-                    if debug == 1:
+                    if self.debug == True:
                         print("press BACK")
                     return False
 
@@ -305,14 +303,14 @@ class autoDevice(QThread):
                     ti = self.get_obj(str(ERROR_CHECK_LAYOUT), True)
                     if ti:
                         self.screenshot()
-                        if debug == 1:
+                        if self.debug == True:
                             print(ti)
                         ti.touch()
                         break
                 QTest.qWait(1000)
                 self.vc.device.press("BACK")
                 QTest.qWait(1000)
-                if debug == 1:
+                if self.debug == True:
                     print("press BACK")
                 return False
 
@@ -359,7 +357,7 @@ class autoDevice(QThread):
             if stair == REMOVE_START:
                 obj = self.get_obj("text:" + self.device_name, True)
                 if obj:
-                    if debug == 1:
+                    if self.debug == True:
                         print(obj)
                     (x, y) = obj.getCenter()
                     self.device.drag((x, y), (x, y), 2000, 1)
@@ -378,7 +376,7 @@ class autoDevice(QThread):
                 else:
                     obj = self.get_obj(str(stair))
                 if obj:
-                    if debug == 1:
+                    if self.debug == True:
                         print(obj)
                     obj.touch()
                     stair = stair + 1

--- a/src/common/common_window.py
+++ b/src/common/common_window.py
@@ -46,7 +46,7 @@ class CommonWindow(QMainWindow):
         self.ui = uic.loadUi(Utils.get_view_path(view_name), self)
         title = f'{CommandUtil.get_device_type_by_device_id(device_info.device_id)}-{device_info.device_num}'
         if device_info.ioter_name is not None:
-            title = title[:-1] + " Binary : " + device_info.ioter_name + "]"
+            title = title[:-1] + " Binary : " + device_info.ioter_name
         self.title = title
         self.setWindowTitle(title)
         self.init_icon(icon_name)

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -1,22 +1,37 @@
 from common.utils import Utils
-
 import json
 
 class Config:
-    CONFIG_FILE = Utils.get_tmp_path() + 'config.json'
-    test_window_shown = False
+    def __init__(cls):
+        super(Config, cls).__init__()
+        cls.load()
 
-    @classmethod
+    def init_config_data(cls):
+        cls.option_menu_shown = False
+        cls.thread_debug_level = 4
+        cls.default_thread_type = 'fed'
+        cls.auto_onboarding_debug_mode = False
+
     def load(cls):
         try:
-            with open(cls.CONFIG_FILE, 'r') as f:
+            with open(Utils.get_config_path(), 'r') as f:
                 config_data = json.load(f)
-            cls.test_window_shown = config_data.get('test_window_shown', cls.test_window_shown)
+            cls.option_menu_shown = config_data['option_menu_shown']
+            cls.thread_debug_level = config_data['thread_debug_level']
+            cls.default_thread_type = config_data['default_thread_type']
+            cls.auto_onboarding_debug_mode = config_data['auto_onboarding_debug_mode']
         except Exception:
-            pass
+            cls.init_config_data()
 
-    @classmethod
     def save(cls):
-        config_data = {'test_window_shown': cls.test_window_shown}
-        with open(cls.CONFIG_FILE, 'w') as f:
-            json.dump(config_data, f)
+        config_data = {
+            'option_menu_shown': cls.option_menu_shown,
+            'thread_debug_level': cls.thread_debug_level,
+            'default_thread_type': cls.default_thread_type,
+            'auto_onboarding_debug_mode': cls.auto_onboarding_debug_mode
+        }
+        try:
+            with open(Utils.get_config_path(), 'w') as f:
+                json.dump(config_data, f, indent=4)
+        except Exception:
+            print("failed to save config data")

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -49,6 +49,12 @@ class Utils():
     def get_ioter_path():
         return os.path.join(Utils.get_base_path(), "bin/")
 
+    def get_source_path():
+        return os.path.join(Utils.get_base_path(), "src/")
+
+    def get_config_path():
+        return os.path.join(Utils.get_source_path(), "config.json")
+
     def get_setup_code(code):
         setup_code = code.split(":")
         return setup_code[1]

--- a/src/config.json
+++ b/src/config.json
@@ -1,0 +1,6 @@
+{
+    "option_menu_shown": false,
+    "thread_debug_level": 4,
+    "default_thread_type": "fed",
+    "auto_onboarding_debug_mode": false
+}


### PR DESCRIPTION
apply default config data from 'config.json' when start ioter.
save config data to 'config.json' when exit program

1. load & save 'Option menu' shown state(default False)
- click ioter logo 10 times then appear Option menu.
- also repeat 10 times click then disappear Option menu.
- this state maintains after program exit
2. load thread debug level (default 4)
3. load thread type (default fed)
4. load auto onboarding debug mode (default False)