### PR TITLE
sync project-chip/connectedhomeip

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = third_party/openthread/ot-samsung
 	url = https://github.com/junyong-sim/openthread
 	branch = feature/contribution-ioter-c1
+[submodule "third_party/connectedhomeip"]
+	path = third_party/connectedhomeip
+	url = https://github.com/junyong-sim/connectedhomeip
+	branch = feature/ioter


### PR DESCRIPTION
Issue : (https://github.com/Samsung/ioter/issues/42)

add submodule "third_party/connectedhomeip"