### PR TITLE
clean matter and thread data when main program starts

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -140,6 +140,11 @@ class Utils():
                 return False
         return True
 
+    ## Remove Data files ##
+    def remove_data_files():
+        Utils.remove_files('/tmp', 'chip_*')
+        Utils.remove_files(Utils.get_tmp_path(), '0_*.data')
+
     ## Remove Matter files ##
     def remove_matter_files(device_num):
         Utils.remove_files('/tmp', 'chip_*' + 'device' + str(device_num) + "*")

--- a/src/main.py
+++ b/src/main.py
@@ -68,6 +68,12 @@ class MainWindow(QMainWindow,
     ## Initialize Main Window class ##
     def __init__(self, window_manager):
         super().__init__()
+
+        # Pre Main
+        Utils.remove_data_files()
+        self.checkDir()
+
+        # Start Main
         self.setupUi(self)
 
         self.dialog = dict()
@@ -106,7 +112,6 @@ class MainWindow(QMainWindow,
         self.polling_time_ms = 50
         self.initPositionTimer()
         self.savePos()
-        self.checkDir()
 
         self.default_config = Config()
         self.default_config_apply()


### PR DESCRIPTION
issue : https://github.com/Samsung/ioter/issues/62

We already had the logic removing matter and thread setting file when device is terminated.
But, some data files are not cleaned sometimes after main program is exited.
To prevent this bug, I added this patch.