### PR TITLE
Fix LightWindow crashes

### DIFF
--- a/src/common/common_window.py
+++ b/src/common/common_window.py
@@ -205,7 +205,7 @@ class CommonWindow(QMainWindow):
                 f'[Send] {self.level}{BATTERY_UNIT}')
             
     def eventFilter(self, obj, event):
-        if obj is self.spinboxBattery and event.type() == QEvent.KeyPress:
+        if event.type() == QEvent.KeyPress and obj is self.spinboxBattery:
             if event.key() in (Qt.Key_Return, Qt.Key_Enter):
                 level = self.spinboxBattery.value()
                 self.update_battery_sensor(level)

--- a/src/things/humidity.py
+++ b/src/things/humidity.py
@@ -183,7 +183,7 @@ class HumidWindow(QDialog):
 
     ## UI event handler ##
     def eventFilter(self, obj, event):
-        if obj is self.doubleSpinBoxInput and event.type() == QEvent.KeyPress:
+        if event.type() == QEvent.KeyPress and obj is self.doubleSpinBoxInput:
             if event.key() in (Qt.Key_Return, Qt.Key_Enter):
                 self.input_click()
                 return True

--- a/src/things/light.py
+++ b/src/things/light.py
@@ -308,7 +308,7 @@ class LightWindow(QDialog):
 
     ## UI event handler ##
     def eventFilter(self, obj, event):
-        if (obj is self.spinboxDimming or obj is self.spinboxColorTemp) and event.type() == QEvent.KeyPress:
+        if event.type() == QEvent.KeyPress and (obj is self.spinboxDimming or obj is self.spinboxColorTemp):
             if event.key() in (Qt.Key_Return, Qt.Key_Enter):
                 self.update_light(
                     EVENT_SPINBOX_DIMMING if obj is self.spinboxDimming else EVENT_SPINBOX_COLOR)

--- a/src/things/lightsensor.py
+++ b/src/things/lightsensor.py
@@ -187,7 +187,7 @@ class LightsensorWindow(QDialog):
 
     ## UI event handler ##
     def eventFilter(self, obj, event):
-        if obj is self.spinBoxInput and event.type() == QEvent.KeyPress:
+        if event.type() == QEvent.KeyPress and obj is self.spinBoxInput:
             if event.key() in (Qt.Key_Return, Qt.Key_Enter):
                 self.input_click()
                 return True

--- a/src/things/temperature.py
+++ b/src/things/temperature.py
@@ -185,7 +185,7 @@ class TempWindow(QDialog):
 
     ## UI event handler ##
     def eventFilter(self, obj, event):
-        if obj is self.doubleSpinBoxInput and event.type() == QEvent.KeyPress:
+        if event.type() == QEvent.KeyPress and obj is self.doubleSpinBoxInput:
             if event.key() in (Qt.Key_Return, Qt.Key_Enter):
                 self.input_click()
                 return True


### PR DESCRIPTION
[Problem] When close the Light bulb widget, it sometimes crash. And it happens more easily from slow PC
[Cause] QEvent 16 occurs and it seems that comes with destroyed signal. (But not always)
[Measure] Check the value of QEvent first