### PR TITLE
[support homepod mini] add route info to table

### DIFF
--- a/src/common/common_window.py
+++ b/src/common/common_window.py
@@ -245,6 +245,9 @@ class CommonWindow(QMainWindow):
             self.device_info.set_commissioning_state(False)
             if self.chkbox_auto.isChecked():
                 self.auto_go()
+        elif step == 60:
+            # set routing information
+            Utils.add_route_with_device_num(int(self.device_info.device_num))
         elif step == 80 and self.device_info.get_commissioning_state():
             self.stackedWidget.setCurrentIndex(1)
             self.progressBar.setValue(100)

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -281,6 +281,18 @@ class Utils():
             pass
         return ver
 
+    # Add thread interface to routing table
+    def add_route_with_device_num(device_num):
+        interface = f"wpan{device_num}"
+        priority = 256 - device_num
+        command = f"sudo ip -6 route add default dev {interface} metric {priority}"
+        try:
+            subprocess.run(command, shell=True, check=True)
+            print(f"Route added for {interface} with priority {priority}.")
+        except subprocess.CalledProcessError as e:
+            print("Error executing command:", e)
+
+
 ## Singleton ##
 def singleton(cls_):
     class class_w(cls_):


### PR DESCRIPTION
issue : https://github.com/Samsung/ioter/issues/23

I had some troubles to test ioter with homepod mini and it took me a little efforts to fix them.

- Bluetooth problem
 To make ble connection between homepod mini and ioter, we have to modify bluetooth.service file. I've checked it's working well in ubutu 22.04.
```
$ sudo vi /lib/systemd/system/bluetooth.service
# insert "-P battery" parameter in ExecStart
ExecStart=/usr/lib/bluetooth/bluetoothd -P battery

```
reference : https://github.com/hbldh/bleak/issues/393

- IP routing problem
While establishing case session, it returned following errors. 
```
[2023-05-30 19:03:28.228548][36520:36520] CHIP:SC: Failed to send status report message: ../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:414: OS Error 0x02000065: Network is unreachable
[2023-05-30 19:03:28.228575][36520:36520] CHIP:IN: CASE Session establishment failed: ../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/inet/UDPEndPointImplSockets.cpp:414: OS Error 0x02000065: Network is unreachable
```
To fix this issue, I added some route info based on thread interface. This PR is related to this issue.

JIRA ticket : https://mobilerndhub.sec.samsung.net/its/browse/IOTER-97