### PR TITLE
auto-yes when apt installation

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -7,8 +7,8 @@ test -r ${CONFIG_SCRIPT} && . ${CONFIG_SCRIPT}
 
 python3_install()
 {
-    sudo apt-get install python3 cmake
-    sudo apt-get install git gcc g++ pkg-config libssl-dev libdbus-1-dev \
+    sudo apt-get -y install python3 cmake
+    sudo apt-get -y install git gcc g++ pkg-config libssl-dev libdbus-1-dev \
         libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev \
         python3-pip unzip libgirepository1.0-dev libcairo2-dev libreadline-dev
     sudo pip install pyQt5


### PR DESCRIPTION
when try to install necessary package, need to type "y". it is better to automatically put "y" option