### PR TITLE
[AutoOnboarding] Fix result dialog issue

### DIFF
--- a/src/auto_onboarding/auto_onboardingmain.py
+++ b/src/auto_onboarding/auto_onboardingmain.py
@@ -71,6 +71,7 @@ class report(QDialog):
         uic.loadUi(Utils.get_view_path('reportDialog.ui'), self)
         self.reset()
         self.btn_quit.clicked.connect(self.dlg_quit)
+        self.btn_save_and_quit.setVisible(False)
         self.setWindowTitle("Onboarding Report")
 
     ## Quit report dialog ##

--- a/src/common/common_window.py
+++ b/src/common/common_window.py
@@ -475,7 +475,7 @@ class CommonWindow(QMainWindow):
 
     ## Check window postion ##
     def checkPosition(self):
-        if self.timer is not None and not self.timer.isActive():
+        if self.timer is None or not self.timer.isActive():
             return
         if self.frameGeometry() == self.cur_pos:
             # Window stopped to move


### PR DESCRIPTION
[Problem]
1. After a repeat test ends, 'Save and quit' button is not working
2. The below logs keep printing Traceback (most recent call last):
File "/home/matter/spdkimo/ioter/src/common/common_window.py", line 472, in checkPosition self.timer.stop()
AttributeError: 'NoneType' object has no attribute 'stop'

[Measure]
1. Remove button
2. Update the timer check condition