### PR TITLE
Unable to select device type options

### DIFF
--- a/src/automation/ProcessCmd.py
+++ b/src/automation/ProcessCmd.py
@@ -98,6 +98,7 @@ class ProcessCmd(QThread):
         super().__init__()
         print('ProcessCmd init')
         self.parent = parent
+        self.commandList = parent.loadCommandList()
         self.scriptFilePath = aFilePath
 
         self.exec_stop = False
@@ -164,7 +165,7 @@ class ProcessCmd(QThread):
                             self.setSleep(sleepInterval)
                         else:
                             print(child.tag, child.attrib)
-                            ExecuteCmd(self.parent.commandList, child.get('devType'), child.get(
+                            ExecuteCmd(self.commandList, child.get('devType'), child.get(
                                 'cmdName'), child.get('val')).execCmd()
                             self.setSleep(1)
                     print('Current Loop Count->', curCnt)
@@ -175,7 +176,7 @@ class ProcessCmd(QThread):
                 self.send_highlight(uiIdx)
                 uiIdx += 1
             else:
-                ExecuteCmd(self.parent.commandList, element.get('devType'), element.get(
+                ExecuteCmd(self.commandList, element.get('devType'), element.get(
                     'cmdName'), element.get('val')).execCmd()
                 self.send_highlight(uiIdx)
                 uiIdx += 1

--- a/src/automation/automationmain.py
+++ b/src/automation/automationmain.py
@@ -69,7 +69,6 @@ class automationWindow(QtWidgets.QMainWindow):
         self.force_quit = False
         self.currentOpenFile = None
         self.devMgrObj = parent.deviceManager
-        self.commandList = dict()
         uic.loadUi(Utils.get_view_path('automationwindow.ui'), self)
         self.resize(600, 700)
         self.setWindowTitle('Automation')
@@ -104,13 +103,14 @@ class automationWindow(QtWidgets.QMainWindow):
         self.actionExit.triggered.connect(self.close)
         self.testprogressBar.setMinimum(0)
         self.show()
-        self.loadCommandList()
 
     ## Load Commands ##
     def loadCommandList(self):
+        cmdLst = dict()
         for device in self.devMgrObj.get_used_devices():
             if device.get_commissioning_state():
-                self.commandList[device.device_num] = self.parent.dialog[device.com_port]._return_command()
+                cmdLst[device.device_num] = self.parent.dialog[device.com_port]._return_command()
+        return cmdLst
 
     ## Handle scroll bar to bootom##
     def scrollToBottom(self, minVal=None, maxVal=None):

--- a/src/automation/devicelayout.py
+++ b/src/automation/devicelayout.py
@@ -60,7 +60,7 @@ class Ui_Device(object):
             "background-color: rgb(255, 163, 72);")
         self.comboBox_devicetype.setObjectName("devicetype")
         self.comboBox_devicetype.addItem("Device Type")
-        self.commandList = parent.commandList
+        self.commandList = parent.loadCommandList()
         self.comboBox_devicetype.currentIndexChanged.connect(
             self.changecomboBox_devicetype)
         self.horizontalLayout.addWidget(self.comboBox_devicetype)


### PR DESCRIPTION
[Problem] After onboarding second device with automation window open, unable to select device options
          for second onboarded device
[Cause]   Command list updated only once
[Measure] Command list updating based on UI updation
Signed-off-by: Bahubali Gumaji <bahubali.bg@samsung.com>